### PR TITLE
Pandar driver ready for Bloom release

### DIFF
--- a/.gitignore/.gitignore
+++ b/.gitignore/.gitignore
@@ -1,1 +1,47 @@
-build
+# GNU global tags
+GTAGS
+GRTAGS
+GSYMS
+GPATH
+
+# Python byte-compile file
+__pycache__/
+*.py[co]
+.ycm_extra_conf.py
+# editor backup files
+*~
+\#*\#
+
+# backup files
+*.bak
+
+# Eclipse
+.cproject
+.project
+.pydevproject
+.settings/
+
+# Visual Studio Code
+.vscode/
+
+# CLion
+.idea/
+cmake-build-debug/
+
+# clang-format
+#.clang-format
+
+# ROSBag files
+*.bag
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+
+# Autoware Resources
+*.pcap
+*.pcd
+*.bag

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+sudo: required
+dist: trusty
+language: generic
+compiler:
+  - gcc
+env:
+  matrix:
+    - ROS_DISTRO="kinetic" ROS_REPO=ros CATKIN_CONFIG="-DCMAKE_BUILD_TYPE=Release" DOCKER_BASE_IMAGE=ros:kinetic-perception
+    - ROS_DISTRO="melodic" ROS_REPO=ros CATKIN_CONFIG="-DCMAKE_BUILD_TYPE=Release" DOCKER_BASE_IMAGE=ros:melodic-perception
+
+install:
+  git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
+script:
+  source .ci_config/travis.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,10 +5,11 @@ catkin_package(
     CATKIN_DEPENDS)
 
 find_package(catkin REQUIRED COMPONENTS
-    image_transport
     roscpp
     roslib
     sensor_msgs
+    std_msgs
+    image_transport
 )
 
 find_package( Boost REQUIRED )
@@ -17,29 +18,79 @@ find_package( PCL REQUIRED COMPONENTS common )
 catkin_package()
 set (CMAKE_CXX_FLAGS "-fPIC --std=c++11")
 
-add_subdirectory(src/Pandar40P)
+#################### Pandar40P Library
+add_library(Pandar40P
+        src/Pandar40P/src/Pandar40P/src/input.cc
+        src/Pandar40P/src/Pandar40P/src/pandar40p_internal.cc
+        src/Pandar40P/src/Pandar40P/src/pandar40p.cc
+        )
 
-include_directories(
-    .
-    src/Pandar40P/src/Pandar40P/include
-    src/Pandar40P/include
-    ${Boost_INCLUDE_DIRS}
-    ${PCL_INCLUDE_DIRS}
-    ${catkin_INCLUDE_DIRS}
+target_include_directories(Pandar40P PRIVATE
+        src/Pandar40P/src/Pandar40P/
+        src/Pandar40P/src/Pandar40P/include
+        ${Boost_INCLUDE_DIRS}
+        ${PCL_INCLUDE_DIRS}
 )
+
+target_link_libraries(Pandar40P
+        ${Boost_LIBRARIES}
+        ${PCL_IO_LIBRARIES}
+        )
+
+#################### Pandar40PSDK
+
+add_library( Pandar40PSDK SHARED
+        src/Pandar40P/src/pandar40p_sdk.cc
+        src/Pandar40P/src/tcp_command_client.c
+        src/Pandar40P/src/util.c
+        )
+
+target_include_directories(Pandar40PSDK PRIVATE
+        src/Pandar40P/
+        src/Pandar40P/include/
+        src/Pandar40P/src/Pandar40P/include/
+        ${Boost_INCLUDE_DIRS}
+        ${PCL_INCLUDE_DIRS}
+        ${OpenCV_INCLUDE_DIRS}
+)
+
+target_link_libraries(Pandar40PSDK
+        Pandar40P
+        ${Boost_LIBRARIES}
+        ${PCL_IO_LIBRARIES}
+        yaml-cpp
+        )
+
+#################### ROS NODE
 
 add_executable(pandar40p_node
-    src/main.cc
-)
+        src/main.cc
+        )
+target_include_directories(pandar40p_node PRIVATE
+        src/Pandar40P/src/Pandar40P/include
+        src/Pandar40P/include
+        ${Boost_INCLUDE_DIRS}
+        ${PCL_INCLUDE_DIRS}
+        ${catkin_INCLUDE_DIRS}
+        )
 
 target_link_libraries(pandar40p_node
-    Pandar40PSDK
-    ${catkin_LIBRARIES}
-)
+        Pandar40PSDK
+        ${catkin_LIBRARIES}
+        )
 
-install(DIRECTORY include/
-        DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
+###############################
+
 install(DIRECTORY launch/
         DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch)
 install(TARGETS pandar40p_node
         RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+
+install(TARGETS
+        Pandar40P
+        Pandar40PSDK
+        pandar40p_node
+        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+        )

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This repository includes the ROS Driver for the Pandar40p LiDAR sensor manufactured by Hesai Technology.
 
+[![Build Status](https://travis-ci.org/amc-nu/Pandar40p_ros.svg?branch=master)](https://travis-ci.org/amc-nu/Pandar40p_ros)
+
 ## How to Build
 
 ### Install `catkin_tools`

--- a/README.md
+++ b/README.md
@@ -1,21 +1,58 @@
-# pandar40p_ros
+# Hesai Pandar40P 
 
-## Build
-```
-mkdir -p rosworkspace/src
-cd rosworkspace/src
-git clone https://github.com/HesaiTechnology/Pandar40p_ros.git --recursive
-cd ..
-catkin_make
-```
+This repository includes the ROS Driver for the Pandar40p LiDAR sensor manufactured by Hesai Technology.
 
-## Run
+## How to Build
+
+### Install `catkin_tools`
+
 ```
-source devel/setup.sh
-roslaunch pandar pandar40p_driver.launch
+$ sudo apt-get update
+$ sudo apt-get install python-catkin-tools
 ```
 
-## ROS Topic name
+### Compile
+
+1. Create ROS Workspace. i.e. `rosworkspace`
+```
+$ mkdir -p rosworkspace/src
+$ cd rosworkspace/src
+```
+
+2. Clone recursively this repository.
+3. Install required dependencies with the help of `rosdep` 
+```
+$ cd ..
+$ rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO 
+```
+4. Compile
+```
+$ catkin config --install
+$ catkin build --force-cmake
+```
+
+## How to Launch
+
+1. While in the `rosworkspace` directory.
+```
+$ source install/setup.bash
+$ roslaunch pandar pandar40p_driver.launch
+```
+2. The driver will publish a PointCloud message in the topic.
 ```
 /pandar40p/sensor/pandar40p/hesai40/PointCloud2
 ```
+3. Open Rviz and add display by topic.
+4. Change fixed frame to match the one in the launch file (Default `hesai40`)
+
+## Available parameters in the Launch file
+
+|Parameter | Default Value|
+|---------|---------------|
+|pandar40p_ip | 192.168.20.51|
+|lidar_recv_port |2368|
+|gps_recv_port  |10110|
+|start_angle |135|
+|timezone| 8|
+|frame_id |hesai40|
+|lidar_topic |/pandar40p/sensor/pandar40p/hesai40/PointCloud2|

--- a/package.xml
+++ b/package.xml
@@ -1,55 +1,22 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>pandar40p</name>
   <version>0.0.0</version>
-  <description>The pandar40p package</description>
-
-  <!-- One maintainer tag required, multiple allowed, one person per tag -->
-  <!-- Example:  -->
-  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
+  <description>
+    The pandar40p package includes the driver for the Heisai Pandar40p LiDAR sensor.
+  </description>
   <maintainer email="wuxiaozhou@hesaitech.com">yy</maintainer>
+  <license>BSD-2</license>
 
-
-  <!-- One license tag required, multiple allowed, one license per tag -->
-  <!-- Commonly used license strings: -->
-  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
-  <license>TODO</license>
-
-
-  <!-- Url tags are optional, but multiple are allowed, one per tag -->
-  <!-- Optional attribute type can be: website, bugtracker, or repository -->
-  <!-- Example: -->
-  <!-- <url type="website">http://wiki.ros.org/pandar40p</url> -->
-
-
-  <!-- Author tags are optional, multiple are allowed, one per tag -->
-  <!-- Authors do not have to be maintainers, but could be -->
-  <!-- Example: -->
-  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
-
-
-  <!-- The *_depend tags are used to specify dependencies -->
-  <!-- Dependencies can be catkin packages or system dependencies -->
-  <!-- Examples: -->
-  <!-- Use build_depend for packages you need at compile time: -->
-  <!--   <build_depend>message_generation</build_depend> -->
-  <!-- Use buildtool_depend for build tool packages: -->
-  <!--   <buildtool_depend>catkin</buildtool_depend> -->
-  <!-- Use run_depend for packages you need at runtime: -->
-  <!--   <run_depend>message_runtime</run_depend> -->
-  <!-- Use test_depend for packages you need only for testing: -->
-  <!--   <test_depend>gtest</test_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>sensor_msgs</build_depend>
-  <run_depend>message_runtime</run_depend>  
-  <run_depend>image_transport</run_depend>
-  <run_depend>std_msgs</run_depend>
 
-
-  <!-- The export tag contains other, unspecified, tags -->
-  <export>
-    <!-- Other tools can request additional information be placed here -->
-
-  </export>
+  <depend>roscpp</depend>
+  <depend>roslib</depend>
+  <depend>std_msgs</depend>
+  <depend>sensor_msgs</depend>
+  <depend>message_runtime</depend>
+  <depend>yaml-cpp</depend>
+  <depend>libpcl-all-dev</depend>
+  <depend>image_transport</depend>
+  <depend>pcl_conversions</depend>
 </package>


### PR DESCRIPTION
The package's `CMakeLists.txt`, and its `package.xml` files include some issues that limit its Bloom release:
* Incorrect Install commands.
* Missing dependencies.
* Incorrect building order.

This PR:
* Fixes the mentioned issues,
* Adds industrial_ci support: https://travis-ci.org/amc-nu/Pandar40p_ros , and
* Improves the README file for the users.

Merging this PR will:
* Allow the automatic installation of the dependencies using `rosdep` (for source builds).
* Help verify that new pull requests get verified in a clean environment. (if TravisCI is enabled by the mainteners).
* Ease the quick deployment of this package to the ROS repositories using Bloom.

### NOTE
We found that the source code of the included library declares `Apache 2.0` license. However, this package declares BSD-2. 

We recommend:
1. To clarify the license (i.e. changing the package and GitHub repository license to Apache 2.0 to match the library license).
1. Release the package to ROS using [Bloom](http://wiki.ros.org/bloom/Tutorials/FirstTimeRelease) for at least ROS Melodic and Kinetic. In this way, customers will be able to easily install the driver for the Pandar LiDAR using `apt` in their ROS environment.

Please let us know if we there is anything we can help to get this merged and released. 